### PR TITLE
Remove --params option and simplify to environment variables only v0.4.0

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/commands/deploy.ts
+++ b/lctl/src/commands/deploy.ts
@@ -8,7 +8,6 @@ export interface DeployOptions {
   runtime?: string;
   handler?: string;
   role?: string;
-  params?: string[];
   config?: string;
   function?: string;
   region?: string;
@@ -22,21 +21,8 @@ export async function deployCommand(functionName: string, options: DeployOptions
   try {
     logger.info(`Deploying Lambda function: ${chalk.cyan(functionName)}`);
 
-    // Parse parameters
-    const params: Record<string, string> = {};
-    if (options.params) {
-      for (const param of options.params) {
-        const [key, value] = param.split('=');
-        if (key && value) {
-          params[key] = value;
-        } else {
-          throw new Error(`Invalid parameter format: ${param}. Use key=value format.`);
-        }
-      }
-    }
-
     // Load configuration
-    const configManager = new ConfigManager(functionName, params, logger);
+    const configManager = new ConfigManager(functionName, logger);
     const config = await configManager.loadConfig({
       runtime: options.runtime,
       handler: options.handler,

--- a/lctl/src/commands/export.ts
+++ b/lctl/src/commands/export.ts
@@ -7,7 +7,6 @@ export interface ExportOptions {
   runtime?: string;
   handler?: string;
   role?: string;
-  params?: string[];
   config?: string;
   function?: string;
   region?: string;
@@ -22,21 +21,8 @@ export async function exportCommand(functionName: string, options: ExportOptions
   try {
     logger.info(`Exporting deploy script for Lambda function: ${chalk.cyan(functionName)}`);
 
-    // Parse parameters
-    const params: Record<string, string> = {};
-    if (options.params) {
-      for (const param of options.params) {
-        const [key, value] = param.split('=');
-        if (key && value) {
-          params[key] = value;
-        } else {
-          throw new Error(`Invalid parameter format: ${param}. Use key=value format.`);
-        }
-      }
-    }
-
     // Load configuration
-    const configManager = new ConfigManager(functionName, params, logger);
+    const configManager = new ConfigManager(functionName, logger);
     const config = await configManager.loadConfig({
       runtime: options.runtime,
       handler: options.handler,

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -12,7 +12,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.3.0');
+  .version('0.4.0');
 
 // Deploy command
 program
@@ -22,7 +22,6 @@ program
   .option('--runtime <runtime>', 'Runtime environment', 'python3.12')
   .option('--handler <handler>', 'Handler function')
   .option('--role <role-arn>', 'IAM role ARN (required for new functions)')
-  .option('--params <key=value>', 'Parameters for YAML variable substitution', [])
   .option('--config <directory>', 'Config directory path', 'configs')
   .option('--function <directory>', 'Functions directory path', 'functions')
   .option('--region <region>', 'AWS region')
@@ -58,7 +57,6 @@ program
   .option('--runtime <runtime>', 'Runtime environment', 'python3.12')
   .option('--handler <handler>', 'Handler function')
   .option('--role <role-arn>', 'IAM role ARN (required for new functions)')
-  .option('--params <key=value>', 'Parameters for YAML variable substitution', [])
   .option('--config <directory>', 'Config directory path', 'configs')
   .option('--function <directory>', 'Functions directory path', 'functions')
   .option('--output <file>', 'Output script file path')


### PR DESCRIPTION
- Remove --params option from CLI commands
- Simplify variable substitution to only support ${ENV_VAR} format
- Update documentation to reflect environment variable approach
- Remove outdated --params references from README examples
- Update version to 0.4.0

🤖 Generated with [Claude Code](https://claude.ai/code)