### PR TITLE
Fix update-function-configuration options and deployment messages v0.6.0

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/commands/deploy.ts
+++ b/lctl/src/commands/deploy.ts
@@ -36,7 +36,7 @@ export async function deployCommand(functionName: string, options: DeployOptions
       logger.info('Executing deployment script...');
       await executeScript(scriptPath, env, logger);
 
-      logger.success(`✅ Lambda function ${chalk.cyan(actualFunctionName)} deployed successfully!`);
+      // スクリプト内で成功メッセージが出力されるため、ここでは出力しない
 
     } finally {
       // Clean up script file

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -12,7 +12,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.5.0');
+  .version('0.6.0');
 
 // Deploy command
 program

--- a/lctl/src/utils/script-generator.ts
+++ b/lctl/src/utils/script-generator.ts
@@ -25,8 +25,7 @@ if aws lambda get-function --function-name ${functionName} &> /dev/null; then
         --handler ${config.handler} \\
         --role ${config.role} \\
         --timeout ${config.timeout || 3} \\
-        --memory-size ${config.memory || 128} \\
-        --architectures ${config.architecture || 'x86_64'}${this.generateEnvironmentVariablesFlag(config)}${this.generateLayersFlag(config)} | jq .
+        --memory-size ${config.memory || 128}${this.generateEnvironmentVariablesFlag(config)}${this.generateLayersFlag(config)}${this.generateDescriptionFlag(config)} | jq .
 else
     echo "Creating new Lambda function: ${functionName}"
     aws lambda create-function --function-name ${functionName} \\


### PR DESCRIPTION
## Bug Fixes
- Remove invalid --architectures option from update-function-configuration command
- Add --description option to update-function-configuration for existing functions
- Remove duplicate success message from deploy command (script message takes precedence)

## Technical Details
- Architecture can only be set during function creation, not during updates
- AWS CLI update-function-configuration supports: Runtime, Handler, Role, Description, Timeout, MemorySize, Environment, Layers, etc.
- Deployment success message is now shown only once from the generated script

🤖 Generated with [Claude Code](https://claude.ai/code)