### PR TITLE
Fix zip command hanging issue and bump version to 0.9.2

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/commands/makezip.ts
+++ b/lctl/src/commands/makezip.ts
@@ -149,9 +149,9 @@ async function createDeploymentZip(functionsDir: string, config: any, zipFileNam
 function runCommand(command: string, args: string[], logger: Logger): Promise<void> {
   return new Promise((resolve, reject) => {
     logger.verbose(`Running: ${command} ${args.join(' ')}`);
-    
+
     const child = spawn(command, args, {
-      stdio: 'pipe'
+      stdio: 'inherit'
     });
 
     child.on('close', (code) => {

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -13,7 +13,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.9.1');
+  .version('0.9.2');
 
 // Deploy command
 program


### PR DESCRIPTION
- Fix runCommand function in makezip.ts to use stdio: 'inherit' instead of 'pipe'
- This resolves the issue where zip commands would hang due to unprocessed stdout/stderr buffers
- Update version to 0.9.2 in both package.json and src/index.ts

🤖 Generated with [Claude Code](https://claude.ai/code)