### PR TITLE
Improve copyright extraction with smart filtering (v0.2.0)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.1.0');
+  .version('0.2.0');
 
 program
   .command('scan')

--- a/licscan/src/utils/package-parser.ts
+++ b/licscan/src/utils/package-parser.ts
@@ -114,13 +114,34 @@ async function extractCopyright(packageDir: string): Promise<string | undefined>
     const licensePath = path.join(packageDir, filename);
     try {
       const content = await fs.readFile(licensePath, 'utf-8');
-
-      // Look for copyright lines
       const lines = content.split('\n');
-      const copyrightLines = lines
-        .filter((line) => /copyright/i.test(line))
-        .map((line) => line.trim())
-        .slice(0, 3); // Take first 3 copyright lines
+
+      // Smart filtering: extract consecutive copyright lines from the beginning
+      const copyrightLines: string[] = [];
+      let foundFirstCopyright = false;
+      let consecutiveNonCopyrightLines = 0;
+      const maxGap = 2; // Allow up to 2 non-copyright lines before stopping
+
+      for (const line of lines) {
+        const trimmedLine = line.trim();
+        const isCopyrightLine = /copyright/i.test(line);
+
+        if (isCopyrightLine) {
+          foundFirstCopyright = true;
+          consecutiveNonCopyrightLines = 0;
+          copyrightLines.push(trimmedLine);
+        } else if (foundFirstCopyright) {
+          // Check if this is a meaningful line (not just empty or whitespace)
+          if (trimmedLine.length > 0) {
+            consecutiveNonCopyrightLines++;
+            if (consecutiveNonCopyrightLines >= maxGap) {
+              // Too many non-copyright lines, stop here
+              break;
+            }
+          }
+          // Empty lines don't count towards the gap, but we don't add them
+        }
+      }
 
       if (copyrightLines.length > 0) {
         return copyrightLines.join('\n');


### PR DESCRIPTION
Update copyright extraction logic to use smart filtering that extracts consecutive copyright lines from the beginning of LICENSE files, avoiding license text that contains the word "copyright".

Changes:
- Replace simple 3-line limit with intelligent consecutive line detection
- Extract all copyright lines from file header (not just first 3)
- Stop extraction when encountering 2+ non-copyright lines
- Ignore empty lines in gap counting
- Apply to both npm (package-parser) and Python (pyproject-parser)

This ensures complete copyright information is captured while excluding license boilerplate text that mentions "copyright".

Version bump: 0.1.0 → 0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)