### PR TITLE
Add pnpm/yarn support and increase buffer size for large projects (v0…

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.7.0');
+  .version('0.8.0');
 
 program
   .command('scan')


### PR DESCRIPTION
….8.0)

Fix "maxBuffer length exceeded" error and add support for pnpm and yarn package managers.

Changes:

Package manager detection:
- Add detectPackageManager() to identify npm, pnpm, or yarn
- Check for pnpm-lock.yaml and yarn.lock files
- Log detected package manager for debugging

Buffer size increase:
- Increase maxBuffer from 10MB to 50MB for large dependency trees
- Prevents "stdout maxBuffer length exceeded" error

pnpm support:
- Use 'pnpm list --json --depth=999' for pnpm projects
- Handle pnpm's array format in addition to object format
- Add scanPnpmDirectory() to scan .pnpm/ directory structure
- Support pnpm's package@version/node_modules/package format

yarn support:
- Use 'yarn list --json --depth=999' for yarn projects

Fallback improvements:
- Split node_modules scanning into separate functions
- Support pnpm's .pnpm directory for offline fallback
- Better error handling for different package manager structures

This fixes the maxBuffer error that occurs with large projects (hundreds to thousands of dependencies) and adds proper support for pnpm and yarn package managers.

Version bump: 0.7.0 → 0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)