### PR TITLE
Use pnpm path cache and exclude devDependencies (v0.8.2)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.8.1');
+  .version('0.8.2');
 
 program
   .command('scan')


### PR DESCRIPTION
Fix issue where transitive devDependencies were being scanned but not actually installed, causing ENOENT errors.

Problem:
- pnpm list includes devDependencies of dependencies
- These packages are not installed in production mode
- getPackageInfo() couldn't find them, causing errors

Solution:
- Add --prod flag to pnpm list to exclude devDependencies
- Cache actual package paths from pnpm list output
- Use cached paths in getPackageInfo() for direct access
- Eliminates need for .pnpm directory scanning in most cases

Changes:
- Add pnpmPathCache to store package name -> path mappings
- Extract path field from pnpm list output
- Check cache first in getPackageInfo() before fallback logic
- Use 'pnpm list --json --depth=999 --prod' to exclude dev deps

This ensures only production dependencies are scanned and all packages can be found using their actual installation paths.

Version bump: 0.8.1 → 0.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)