### PR TITLE
Fix pnpm scoped packages and use direct .pnpm scan (v0.8.3)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.8.2');
+  .version('0.8.3');
 
 program
   .command('scan')


### PR DESCRIPTION
Fix issues with scoped packages in pnpm and switch to direct .pnpm directory scanning for better support of large projects.

Problems:
- maxBuffer exceeded for very large projects (>50MB output)
- Scoped packages incorrectly resolved (@scope+package vs @scope/package)
- pnpm converts @scope/package to @scope+package in directory names

Solutions:
- For pnpm: scan .pnpm directory directly instead of using pnpm list
- Correctly parse scoped package directory names (@scope+package@version)
- Map directory names to actual package names (@scope/package)
- Cache paths in pnpmPathCache for fast access

Changes:
- Add direct .pnpm scanning as primary method for pnpm
- Improve scanPnpmDirectory() to handle scoped packages correctly
- Parse @scope+package@version_peer-deps format
- Extract package name as @scope/package from directory @scope+package
- Cache package paths during scan for getPackageInfo() usage

This approach works for projects of any size without hitting buffer limits and correctly handles all pnpm package naming conventions.

Version bump: 0.8.2 → 0.8.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)