### PR TITLE
Add Markdown format output with Handlebars templating (v0.9.0)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {
     "licscan": "./bin/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp -r src/templates dist/",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "npm run build && node dist/index.js"
@@ -26,11 +26,13 @@
     "commander": "^14.0.2",
     "chalk": "^5.6.2",
     "glob": "^11.0.3",
-    "smol-toml": "^1.4.2"
+    "smol-toml": "^1.4.2",
+    "handlebars": "^4.7.8"
   },
   "devDependencies": {
     "@types/node": "^24.10.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "@types/handlebars": "^4.1.0"
   },
   "files": [
     "dist/**/*",

--- a/licscan/pnpm-lock.yaml
+++ b/licscan/pnpm-lock.yaml
@@ -17,10 +17,16 @@ importers:
       glob:
         specifier: ^11.0.3
         version: 11.0.3
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
       smol-toml:
         specifier: ^1.4.2
         version: 1.4.2
     devDependencies:
+      '@types/handlebars':
+        specifier: ^4.1.0
+        version: 4.1.0
       '@types/node':
         specifier: ^24.10.0
         version: 24.10.0
@@ -41,6 +47,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@types/handlebars@4.1.0':
+    resolution: {integrity: sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==}
+    deprecated: This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.
 
   '@types/node@24.10.0':
     resolution: {integrity: sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==}
@@ -98,6 +108,11 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -117,9 +132,15 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -148,6 +169,10 @@ packages:
     resolution: {integrity: sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==}
     engines: {node: '>= 18'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -169,6 +194,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -176,6 +206,9 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -201,6 +234,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@types/handlebars@4.1.0':
+    dependencies:
+      handlebars: 4.7.8
 
   '@types/node@24.10.0':
     dependencies:
@@ -252,6 +289,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
 
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   is-fullwidth-code-point@3.0.0: {}
 
   isexe@2.0.0: {}
@@ -266,7 +312,11 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimist@1.2.8: {}
+
   minipass@7.1.2: {}
+
+  neo-async@2.6.2: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -286,6 +336,8 @@ snapshots:
   signal-exit@4.1.0: {}
 
   smol-toml@1.4.2: {}
+
+  source-map@0.6.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -309,11 +361,16 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   undici-types@7.16.0: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,14 +9,14 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.8.3');
+  .version('0.9.0');
 
 program
   .command('scan')
   .description('Scan a project for license and copyright information')
   .argument('[path]', 'Path to project directory', '.')
   .option('-d, --include-dev', 'Include dev dependencies', false)
-  .option('-f, --format <format>', 'Output format (text, json, csv)', 'text')
+  .option('-f, --format <format>', 'Output format (text, json, csv, markdown)', 'text')
   .option('-o, --output <file>', 'Output file path')
   .option('--npm-only', 'Scan only npm dependencies (package.json)', false)
   .option('--python-only', 'Scan only Python dependencies (pyproject.toml)', false)
@@ -33,7 +33,7 @@ program
 program
   .argument('[path]', 'Path to project directory', '.')
   .option('-d, --include-dev', 'Include dev dependencies', false)
-  .option('-f, --format <format>', 'Output format (text, json, csv)', 'text')
+  .option('-f, --format <format>', 'Output format (text, json, csv, markdown)', 'text')
   .option('-o, --output <file>', 'Output file path')
   .option('--npm-only', 'Scan only npm dependencies (package.json)', false)
   .option('--python-only', 'Scan only Python dependencies (pyproject.toml)', false)

--- a/licscan/src/templates/licenses.md.hbs
+++ b/licscan/src/templates/licenses.md.hbs
@@ -1,0 +1,77 @@
+# License Report
+
+## Table of Contents
+
+{{#each npmPackages}}
+- [{{name}}@{{version}}](#{{anchor name version}}) - {{license}}
+{{/each}}
+{{#each pythonPackages}}
+- [{{name}}@{{version}}](#{{anchor name version}}) - {{license}}
+{{/each}}
+
+---
+
+## NPM Packages
+
+{{#each npmPackages}}
+### {{name}}@{{version}}
+
+**License:** {{license}}
+{{#if author}}
+**Author:** {{author}}
+{{/if}}
+{{#if homepage}}
+**Homepage:** {{homepage}}
+{{/if}}
+{{#if repository}}
+**Repository:** {{repository}}
+{{/if}}
+
+{{#if copyright}}
+**Copyright:**
+```
+{{copyright}}
+```
+{{/if}}
+
+{{#if licenseText}}
+**License Text:**
+```
+{{licenseText}}
+```
+{{/if}}
+
+---
+
+{{/each}}
+
+## Python Packages
+
+{{#each pythonPackages}}
+### {{name}}@{{version}}
+
+**License:** {{license}}
+{{#if author}}
+**Author:** {{author}}
+{{/if}}
+{{#if homepage}}
+**Homepage:** {{homepage}}
+{{/if}}
+
+{{#if copyright}}
+**Copyright:**
+```
+{{copyright}}
+```
+{{/if}}
+
+{{#if licenseText}}
+**License Text:**
+```
+{{licenseText}}
+```
+{{/if}}
+
+---
+
+{{/each}}


### PR DESCRIPTION
Implement Markdown format support for better readability of large dependency lists in OSS license compliance reports.

Features:
- Add Markdown format option (-f markdown)
- Use Handlebars template engine for extensibility
- Table of Contents with package list and links
- Detailed package sections with license information
- Automatic header anchor generation for navigation

Implementation:
- Add Handlebars 4.7.8 as dependency
- Create src/templates/licenses.md.hbs template
- Implement formatMarkdown() function in scan.ts
- Register 'anchor' helper for URL-safe anchor generation
- Update build script to copy templates to dist folder
- Update CLI option descriptions to include markdown format

Output structure:
1. Table of Contents: List of all packages with links
2. NPM Packages: Detailed info (license, author, homepage, etc.)
3. Python Packages: Detailed info with full license text

This provides better visibility for large projects and prepares the codebase for future HTML output support.

Version bump: 0.8.3 → 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)