### PR TITLE
Improve Markdown output formatting (v0.9.1)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/commands/scan.ts
+++ b/licscan/src/commands/scan.ts
@@ -257,7 +257,12 @@ async function formatMarkdown(results: ScanResult[]): Promise<string> {
   // Register Handlebars helper for generating anchor links
   Handlebars.registerHelper('anchor', (name: string, version: string) => {
     // Create a URL-safe anchor from package name and version
-    return `${name}-${version}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    // Format: name@version, then convert to lowercase and replace non-alphanumeric chars with hyphens
+    const fullName = `${name}@${version}`;
+    return fullName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric sequences with single hyphen
+      .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
   });
 
   // Load template
@@ -276,6 +281,11 @@ async function formatMarkdown(results: ScanResult[]): Promise<string> {
       pythonPackages.push(...result.packages);
     }
   }
+
+  // Sort packages alphabetically by name
+  const sortPackages = (a: any, b: any) => a.name.localeCompare(b.name);
+  npmPackages.sort(sortPackages);
+  pythonPackages.sort(sortPackages);
 
   // Render template with data
   const output = template({

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.9.0');
+  .version('0.9.1');
 
 program
   .command('scan')

--- a/licscan/src/templates/licenses.md.hbs
+++ b/licscan/src/templates/licenses.md.hbs
@@ -1,30 +1,38 @@
 # License Report
 
 ## Table of Contents
+{{#if npmPackages.length}}
 
+### NPM Packages
 {{#each npmPackages}}
 - [{{name}}@{{version}}](#{{anchor name version}}) - {{license}}
 {{/each}}
+{{/if}}
+{{#if pythonPackages.length}}
+
+### Python Packages
 {{#each pythonPackages}}
 - [{{name}}@{{version}}](#{{anchor name version}}) - {{license}}
 {{/each}}
+{{/if}}
 
 ---
+{{#if npmPackages.length}}
 
 ## NPM Packages
 
 {{#each npmPackages}}
 ### {{name}}@{{version}}
 
-**License:** {{license}}
+- **License:** {{license}}
 {{#if author}}
-**Author:** {{author}}
+- **Author:** {{author}}
 {{/if}}
 {{#if homepage}}
-**Homepage:** {{homepage}}
+- **Homepage:** {{homepage}}
 {{/if}}
 {{#if repository}}
-**Repository:** {{repository}}
+- **Repository:** {{repository}}
 {{/if}}
 
 {{#if copyright}}
@@ -44,18 +52,20 @@
 ---
 
 {{/each}}
+{{/if}}
+{{#if pythonPackages.length}}
 
 ## Python Packages
 
 {{#each pythonPackages}}
 ### {{name}}@{{version}}
 
-**License:** {{license}}
+- **License:** {{license}}
 {{#if author}}
-**Author:** {{author}}
+- **Author:** {{author}}
 {{/if}}
 {{#if homepage}}
-**Homepage:** {{homepage}}
+- **Homepage:** {{homepage}}
 {{/if}}
 
 {{#if copyright}}
@@ -75,3 +85,4 @@
 ---
 
 {{/each}}
+{{/if}}


### PR DESCRIPTION
- Separate ToC sections for NPM and Python packages
- Add alphabetical sorting for packages in both ToC and detail sections
- Format package metadata as bullet list for better readability
- Fix page internal links to be VSCode Markdown Preview compatible
- Hide empty sections when using --npm-only or --python-only options

🤖 Generated with [Claude Code](https://claude.com/claude-code)