### PR TITLE
Fix maxBuffer error by caching dependency list (v0.10.1)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.10.0');
+  .version('0.10.1');
 
 program
   .command('scan')


### PR DESCRIPTION
- Cache npm/pnpm/yarn list command result to avoid running it twice
- Reuse cached result in buildDependencyGraph instead of re-executing
- Prevents maxBuffer exceeded error in large projects
- Improves performance by eliminating redundant command execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)