### PR TITLE
Use pnpm list for accurate dependency tracking (v0.10.2)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.10.1');
+  .version('0.10.2');
 
 program
   .command('scan')


### PR DESCRIPTION
- Remove .pnpm directory scan which included devDependencies
- Always use pnpm/npm/yarn list command for accurate production dependency tracking
- Increase maxBuffer from 50MB to 100MB for large projects
- Ensure only production dependencies are included in output
- Maintain dependency graph information for all package managers

🤖 Generated with [Claude Code](https://claude.com/claude-code)