### PR TITLE
Scan only defined packages, add Python dependency tracking (v0.11.0)

### DIFF
--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.10.3');
+  .version('0.11.0');
 
 program
   .command('scan')


### PR DESCRIPTION
Changes:
- NPM: Only scan packages defined in package.json (not all installed packages)
- Python: Only scan packages defined in pyproject.toml (not all installed packages)
- Add Python dependency graph building using pip show
- Add requiredBy and dependencyPaths for Python packages
- Include direct dependencies from pyproject.toml in dependency graph
- Both NPM and Python now show consistent dependency information

🤖 Generated with [Claude Code](https://claude.com/claude-code)