### PR TITLE
Include transitive dependencies in scan results (v0.12.0)

### DIFF
--- a/licscan/README.md
+++ b/licscan/README.md
@@ -186,35 +186,35 @@ Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
 ## How It Works
 
 ### For npm packages (package.json):
-1. Reads `package.json` to get **only the packages defined** in dependencies (not all nested dependencies)
+1. Reads `package.json` to get the packages defined in dependencies (entry points)
 2. Detects package manager (npm, pnpm, or yarn)
-3. Runs `pnpm list --prod` / `npm list` / `yarn list` to build dependency graph
-4. Tracks relationships between packages (which packages depend on which)
-5. For each defined dependency, reads package.json and LICENSE files
+3. Runs `pnpm list --prod` / `npm list` / `yarn list` to build full dependency graph
+4. Extracts all packages reachable from the defined dependencies (includes **transitive dependencies**)
+5. For each package (direct and transitive), reads package.json and LICENSE files
 6. Extracts license information from package metadata
 7. Extracts copyright information from LICENSE files
 8. Calculates dependency paths from root to each package
 9. Compiles all information with dependency tracking into structured output
 
-**Note:** The tool scans only packages explicitly defined in package.json, not all transitive dependencies. The dependency graph is used to provide `requiredBy` and `dependencyPaths` information.
+**Note:** The tool scans packages defined in package.json and **all their transitive dependencies**. For example, if package.json defines `react`, the output will include `react`, `loose-envify` (dependency of react), `js-tokens` (dependency of loose-envify), etc.
 
 ### For Python packages (pyproject.toml):
 1. Reads `pyproject.toml` (supports both Poetry and PEP 621 formats)
-2. Extracts **only the packages defined** in dependencies (not all installed packages)
+2. Extracts the packages defined in dependencies (entry points)
 3. **Detects Python environment**:
    - Checks for `uv.lock` (uv projects)
    - Checks for `poetry.lock` (Poetry projects)
    - Checks for `VIRTUAL_ENV` environment variable (venv)
    - Checks for common venv directories (`venv`, `.venv`, `env`, `.env`)
    - Falls back to system Python
-4. Uses `pip show` to build dependency graph and track relationships
-5. Tracks which packages depend on each defined package (`requiredBy`)
-6. Calculates dependency paths from root project to each package
-7. Uses appropriate command prefix (`uv run`, `poetry run`, or system)
-8. Attempts to locate and read LICENSE files from installed packages using Python's `importlib.metadata`
+4. Uses `pip show` to build full dependency graph and track relationships
+5. Extracts all packages reachable from the defined dependencies (includes **transitive dependencies**)
+6. For each package, attempts to locate and read LICENSE files using Python's `importlib.metadata`
+7. Calculates dependency paths from root project to each package
+8. Uses appropriate command prefix (`uv run`, `poetry run`, or system)
 9. Compiles all information with dependency tracking into structured output
 
-**Note:** Similar to npm packages, the tool scans only packages explicitly defined in pyproject.toml dependencies, not all installed packages in the environment.
+**Note:** The tool scans packages defined in pyproject.toml and **all their transitive dependencies**. For example, if pyproject.toml defines `graphql-py`, the output will include `graphql-py` and `ply` (dependency of graphql-py).
 
 ## Development
 

--- a/licscan/package.json
+++ b/licscan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/licscan",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "License and Copyright Scanner for package.json and pyproject.toml",
   "main": "dist/index.js",
   "bin": {

--- a/licscan/src/index.ts
+++ b/licscan/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('licscan')
   .description('License and Copyright Scanner for package.json and pyproject.toml')
-  .version('0.11.0');
+  .version('0.12.0');
 
 program
   .command('scan')

--- a/licscan/src/utils/package-parser.ts
+++ b/licscan/src/utils/package-parser.ts
@@ -745,6 +745,38 @@ function findDependencyPaths(
 }
 
 /**
+ * Get all packages reachable from the given root packages (transitive dependencies)
+ */
+export function getAllReachablePackages(
+  rootPackages: Set<string>,
+  graph: DependencyGraph,
+): Set<string> {
+  const reachable = new Set<string>();
+  const visited = new Set<string>();
+
+  function dfs(packageName: string) {
+    if (visited.has(packageName)) {
+      return;
+    }
+    visited.add(packageName);
+    reachable.add(packageName);
+
+    const deps = graph.dependencies.get(packageName);
+    if (deps) {
+      for (const dep of deps) {
+        dfs(dep);
+      }
+    }
+  }
+
+  for (const pkg of rootPackages) {
+    dfs(pkg);
+  }
+
+  return reachable;
+}
+
+/**
  * Get package info with dependency information
  */
 export async function getPackageInfoWithDependencies(


### PR DESCRIPTION
Changes:
- Scan packages defined in package.json/pyproject.toml AND all their transitive dependencies
- Add getAllReachablePackages() to extract all dependencies reachable from entry points
- Add getAllReachablePythonPackages() for Python with normalization support
- Update logging to show "direct dependencies" vs "total packages"
- Update README with correct description of transitive dependency scanning

Example:
- package.json defines 26 packages → scans 235 total packages (including nested)
- pyproject.toml defines graphql-py → scans graphql-py + ply (its dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)