### PR TITLE
revx: Fix path handling to preserve original paths without pathRewrite

### DIFF
--- a/revx/package.json
+++ b/revx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/revx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Reverse proxy CLI tool with YAML configuration",
   "homepage": "https://github.com/tamuto/infodb-cli/",
   "bugs": "https://github.com/tamuto/infodb-cli/issues",

--- a/revx/src/commands/start.ts
+++ b/revx/src/commands/start.ts
@@ -87,7 +87,7 @@ function setupRoutes(
     }
 
     const proxyMiddleware = proxyManager.createProxyMiddleware(route);
-    app.use(route.path, proxyMiddleware);
+    app.use(proxyMiddleware);
   });
 
   app.get('/health', (req: Request, res: Response) => {

--- a/revx/src/index.ts
+++ b/revx/src/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 program
   .name('revx')
   .description('Reverse proxy CLI tool with YAML configuration')
-  .version('0.1.0');
+  .version('0.1.1');
 
 program
   .command('start')

--- a/revx/src/utils/proxy.ts
+++ b/revx/src/utils/proxy.ts
@@ -72,6 +72,7 @@ export class ProxyManager {
 
   createProxyMiddleware(route: RouteConfig) {
     const options: Options = {
+      pathFilter: route.path,
       changeOrigin: route.changeOrigin ?? true,
       ws: route.ws ?? false,
       pathRewrite: route.pathRewrite,


### PR DESCRIPTION
pathRewriteを指定しない場合に元のパスが維持されるように修正

Changes:
- Add pathFilter option to http-proxy-middleware
- Remove path argument from app.use() to prevent Express from stripping paths
- Update version to 0.1.1

Before: /api/users → Express strips /api → /users forwarded
After: /api/users → pathFilter matches → /api/users forwarded (unless pathRewrite specified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)