### PR TITLE
revx: Ignore CONTENT_LENGTH_MISMATCH errors in error handler (v0.2.2)

### DIFF
--- a/revx/package.json
+++ b/revx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/revx",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Reverse proxy CLI tool with YAML configuration",
   "homepage": "https://github.com/tamuto/infodb-cli/",
   "bugs": "https://github.com/tamuto/infodb-cli/issues",

--- a/revx/src/index.ts
+++ b/revx/src/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 program
   .name('revx')
   .description('Reverse proxy CLI tool with YAML configuration')
-  .version('0.2.1');
+  .version('0.2.2');
 
 program
   .command('start')


### PR DESCRIPTION
CONTENT_LENGTH_MISMATCHエラーを無視して正常動作させる

Fix:
- Silently ignore CONTENT_LENGTH_MISMATCH errors in error handler
- These errors are benign - content is already delivered to client
- Only log in verbose mode to avoid noise

Why this approach:
- Previous attempts (removing Content-Length, setting chunked encoding) caused other issues
- CONTENT_LENGTH_MISMATCH occurs AFTER content is successfully transferred
- Vite transforms content dynamically, causing size mismatch
- By the time error is detected, client already has the full response
- Ignoring the error prevents unnecessary 502 responses

Technical details:
- Check error message for 'CONTENT_LENGTH_MISMATCH' string
- Return early from error handler without sending 502
- Add proxyTimeout option for better timeout handling
- Log ignored errors in verbose mode for debugging

Tested with:
- Vite development server
- Handles ESM transformation and HMR injection correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)