### PR TITLE
revx: Major refactor to Vite-focused multi-project dev server (v1.0.0)

### DIFF
--- a/revx/package.json
+++ b/revx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@infodb/revx",
-  "version": "0.4.0",
-  "description": "Reverse proxy CLI tool with YAML configuration",
+  "version": "1.0.0",
+  "description": "Multi-Vite project development server - Host multiple Vite apps on a single port with unified routing",
   "homepage": "https://github.com/tamuto/infodb-cli/",
   "bugs": "https://github.com/tamuto/infodb-cli/issues",
   "repository": {
@@ -10,12 +10,16 @@
     "directory": "revx"
   },
   "keywords": [
+    "vite",
+    "multi-project",
+    "monorepo",
+    "dev-server",
+    "vite-middleware",
+    "hmr",
     "reverse-proxy",
-    "proxy",
-    "cli",
+    "webpack",
     "express",
-    "yaml",
-    "http-proxy"
+    "yaml"
   ],
   "author": "tamuto <tamuto@infodb.jp>",
   "license": "MIT",
@@ -44,6 +48,7 @@
     "express": "^5.1.0",
     "http-proxy-middleware": "^3.0.3",
     "morgan": "^1.10.0",
+    "vite": "^6.0.7",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/revx/sample/revx.mixed.yaml
+++ b/revx/sample/revx.mixed.yaml
@@ -1,0 +1,63 @@
+# revx.mixed.yaml - Mixed Development Servers Example
+# Use this when you have Vite apps alongside webpack/Parcel/other dev servers
+
+# Server settings
+server:
+  port: 3000
+  host: 0.0.0.0
+  name: "Mixed Dev Server (Vite + webpack)"
+  maxSockets: 512
+
+# Global configuration
+global:
+  cors:
+    enabled: true
+    origin: "*"
+
+  logging:
+    enabled: true
+    format: "dev"
+
+# Route definitions
+routes:
+  # New Vite app (native middleware)
+  - path: "/new-app"
+    vite:
+      root: "./apps/new-app"
+      base: "/new-app"
+
+  # Another Vite app
+  - path: "/dashboard"
+    vite:
+      root: "./apps/dashboard"
+      base: "/dashboard"
+
+  # Legacy webpack dev server (reverse proxy)
+  - path: "/legacy/*"
+    target: "http://localhost:8080"
+    ws: true  # Enable WebSocket for webpack HMR
+    changeOrigin: true
+
+  # Parcel dev server (reverse proxy)
+  - path: "/old-app/*"
+    target: "http://localhost:1234"
+    ws: true
+    changeOrigin: true
+
+  # Backend API
+  - path: "/api/*"
+    target: "http://localhost:4000"
+    changeOrigin: true
+    pathRewrite:
+      "^/api": ""
+
+  # Static documentation
+  - path: "/docs"
+    static: "./public/docs"
+
+# Usage:
+# 1. Start webpack dev server: cd apps/legacy && npm run dev (on :8080)
+# 2. Start Parcel: cd apps/old-app && npm run dev (on :1234)
+# 3. Start backend API: cd api && npm run dev (on :4000)
+# 4. Start revx: revx start revx.mixed.yaml
+# 5. Access all apps at http://localhost:3000

--- a/revx/sample/revx.vite.yaml
+++ b/revx/sample/revx.vite.yaml
@@ -1,0 +1,56 @@
+# revx.vite.yaml - Multi-Vite Project Configuration Example
+
+# Server settings
+server:
+  port: 3000
+  host: 0.0.0.0
+  name: "Multi-Vite Dev Server"
+  # Increase max sockets for better performance with Vite
+  maxSockets: 512
+
+# Global configuration
+global:
+  # CORS settings
+  cors:
+    enabled: true
+    origin: "*"
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    credentials: true
+
+  # Logging settings
+  logging:
+    enabled: true
+    format: "dev"  # dev format is good for development
+
+# Route definitions
+routes:
+  # Example 1: Vite project 1 (SPA at /app1)
+  - path: "/app1"
+    vite:
+      root: "./projects/app1"
+      base: "/app1"
+      # Optional: specify custom vite config file
+      # configFile: "./projects/app1/vite.config.ts"
+
+  # Example 2: Vite project 2 (SPA at /app2)
+  - path: "/app2"
+    vite:
+      root: "./projects/app2"
+      base: "/app2"
+
+  # Example 3: Backend API proxy
+  - path: "/api/*"
+    target: "http://localhost:4000"
+    changeOrigin: true
+    pathRewrite:
+      "^/api": ""
+
+  # Example 4: Admin dashboard (static files)
+  - path: "/admin/*"
+    static: "./admin/dist"
+
+  # Example 5: Root Vite project (catches remaining routes)
+  # - path: "/*"
+  #   vite:
+  #     root: "./projects/main"
+  #     base: "/"

--- a/revx/src/commands/validate.ts
+++ b/revx/src/commands/validate.ts
@@ -28,6 +28,14 @@ export async function validateCommand(configFile: string, options: { verbose?: b
           }
         } else if (route.static) {
           logger.info(`     Static: ${route.static}`);
+        } else if (route.vite) {
+          logger.info(`     Vite: ${route.vite.root}`);
+          if (route.vite.base) {
+            logger.info(`     Base: ${route.vite.base}`);
+          }
+          if (route.vite.configFile) {
+            logger.info(`     Config: ${route.vite.configFile}`);
+          }
         }
       });
     }

--- a/revx/src/index.ts
+++ b/revx/src/index.ts
@@ -9,8 +9,8 @@ const program = new Command();
 
 program
   .name('revx')
-  .description('Reverse proxy CLI tool with YAML configuration')
-  .version('0.4.0');
+  .description('Multi-Vite project development server')
+  .version('1.0.0');
 
 program
   .command('start')
@@ -28,8 +28,9 @@ program
 
 program
   .command('init')
-  .description('Create a sample configuration file')
-  .option('--simple', 'Create a simple configuration file')
+  .description('Create a sample configuration file (default: Vite multi-project)')
+  .option('--simple', 'Create a simple Vite proxy configuration')
+  .option('--proxy', 'Create a reverse proxy configuration')
   .option('--output <file>', 'Output file path', 'revx.yaml')
   .option('--verbose', 'Verbose output')
   .action(initCommand);

--- a/revx/src/utils/config.ts
+++ b/revx/src/utils/config.ts
@@ -29,10 +29,17 @@ export interface ServerConfig {
   maxSockets?: number;
 }
 
+export interface ViteConfig {
+  root: string;
+  base?: string;
+  configFile?: string;
+}
+
 export interface RouteConfig {
   path: string;
   target?: string;
   static?: string;
+  vite?: ViteConfig;
   changeOrigin?: boolean;
   pathRewrite?: Record<string, string>;
   ws?: boolean;
@@ -144,13 +151,20 @@ export class ConfigLoader {
 
     const hasTarget = !!route.target;
     const hasStatic = !!route.static;
+    const hasVite = !!route.vite;
 
-    if (!hasTarget && !hasStatic) {
-      throw new Error(`Route ${route.path} must have either target or static`);
+    const routeTypes = [hasTarget, hasStatic, hasVite].filter(Boolean).length;
+
+    if (routeTypes === 0) {
+      throw new Error(`Route ${route.path} must have either target, static, or vite`);
     }
 
-    if (hasTarget && hasStatic) {
-      throw new Error(`Route ${route.path} cannot have both target and static`);
+    if (routeTypes > 1) {
+      throw new Error(`Route ${route.path} can only have one of: target, static, or vite`);
+    }
+
+    if (hasVite && !route.vite!.root) {
+      throw new Error(`Route ${route.path} vite configuration requires 'root' field`);
     }
   }
 }

--- a/revx/src/utils/logger.ts
+++ b/revx/src/utils/logger.ts
@@ -1,7 +1,11 @@
 import chalk from 'chalk';
 
 export class Logger {
-  constructor(private isVerbose: boolean = false) {}
+  constructor(private verboseMode: boolean = false) {}
+
+  isVerbose(): boolean {
+    return this.verboseMode;
+  }
 
   info(message: string): void {
     console.log(chalk.blue('ℹ'), message);
@@ -20,7 +24,7 @@ export class Logger {
   }
 
   verbose(message: string, data?: any): void {
-    if (this.isVerbose) {
+    if (this.verboseMode) {
       console.log(chalk.gray('🔍'), chalk.gray(message));
       if (data) {
         console.log(chalk.gray(JSON.stringify(data, null, 2)));
@@ -29,7 +33,7 @@ export class Logger {
   }
 
   debug(message: string, data?: any): void {
-    if (this.isVerbose) {
+    if (this.verboseMode) {
       console.log(chalk.magenta('🐛'), chalk.magenta(message));
       if (data) {
         console.log(chalk.magenta(JSON.stringify(data, null, 2)));

--- a/revx/src/utils/vite-middleware.ts
+++ b/revx/src/utils/vite-middleware.ts
@@ -1,0 +1,77 @@
+import { ViteDevServer, createServer, InlineConfig } from 'vite';
+import { RequestHandler } from 'express';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { RouteConfig } from './config.js';
+import { Logger } from './logger.js';
+
+export class ViteMiddlewareManager {
+  private viteServers: Map<string, ViteDevServer> = new Map();
+
+  constructor(private logger: Logger) {}
+
+  async createViteMiddleware(route: RouteConfig): Promise<RequestHandler> {
+    if (!route.vite) {
+      throw new Error('Route does not have vite configuration');
+    }
+
+    const rootPath = resolve(process.cwd(), route.vite.root);
+
+    if (!existsSync(rootPath)) {
+      this.logger.error(`Vite root directory does not exist: ${rootPath}`);
+      throw new Error(`Vite root directory not found: ${rootPath}`);
+    }
+
+    this.logger.info(`Creating Vite middleware: ${route.path} -> ${rootPath}`);
+
+    const viteConfig: InlineConfig = {
+      root: rootPath,
+      base: route.vite.base || route.path,
+      configFile: route.vite.configFile,
+      server: {
+        middlewareMode: true,
+        hmr: {
+          // Use the parent server's port for HMR
+          clientPort: undefined,
+        },
+      },
+      // Suppress Vite's own logging since we're using our logger
+      logLevel: this.logger.isVerbose() ? 'info' : 'warn',
+    };
+
+    try {
+      const vite = await createServer(viteConfig);
+      this.viteServers.set(route.path, vite);
+
+      this.logger.verbose(`Vite server created for ${route.path}`, {
+        root: rootPath,
+        base: viteConfig.base,
+      });
+
+      return vite.middlewares;
+    } catch (error) {
+      if (error instanceof Error) {
+        this.logger.error(`Failed to create Vite server for ${route.path}: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    this.logger.info('Closing Vite servers...');
+    const closePromises = Array.from(this.viteServers.values()).map((vite) =>
+      vite.close()
+    );
+    await Promise.all(closePromises);
+    this.viteServers.clear();
+    this.logger.verbose('All Vite servers closed');
+  }
+
+  getServer(path: string): ViteDevServer | undefined {
+    return this.viteServers.get(path);
+  }
+
+  getServerCount(): number {
+    return this.viteServers.size;
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: Repositioned revx as a Vite-first development tool

Major Changes:
- Move Vite from peerDependencies to dependencies for better UX
- Change default `revx init` to generate Vite multi-project config
- Add native Vite middleware integration via ViteMiddlewareManager
- Implement complete WebSocket upgrade handling for webpack/Parcel HMR
- Update package description and keywords to emphasize Vite focus

Features:
- Host multiple Vite projects on single port with native HMR
- Support mixed dev servers (Vite + webpack + Parcel) via proxy
- Automatic WebSocket routing for proxied dev servers
- Path-based routing with automatic route sorting

New Files:
- src/utils/vite-middleware.ts: ViteMiddlewareManager class
- sample/revx.vite.yaml: Multi-Vite project example
- sample/revx.mixed.yaml: Vite + webpack integration example

Updated Files:
- package.json: v1.0.0, Vite as dependency, updated keywords
- src/commands/start.ts: WebSocket upgrade handler, Vite integration
- src/utils/proxy.ts: ProxyInfo tracking for WebSocket routing
- README.md: Complete rewrite emphasizing Vite use cases

Migration Guide:
- Vite now included by default (no separate install needed)
- `revx init` generates Vite config by default
- Use `revx init --proxy` for traditional reverse proxy config
- webpack/Parcel HMR works with just `ws: true` in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)