### PR TITLE
revx: Add debug logging for WebSocket upgrade tracking (v1.0.2)

### DIFF
--- a/revx/package.json
+++ b/revx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/revx",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Multi-Vite project development server - Host multiple Vite apps on a single port with unified routing",
   "homepage": "https://github.com/tamuto/infodb-cli/",
   "bugs": "https://github.com/tamuto/infodb-cli/issues",

--- a/revx/src/commands/start.ts
+++ b/revx/src/commands/start.ts
@@ -130,12 +130,17 @@ async function startServer(
     server.on('upgrade', (req, socket, head) => {
       const urlPath = req.url || '/';
 
+      logger.info(`WebSocket upgrade request: ${urlPath}`);
+
       // First, check if this is a Vite HMR WebSocket request
       const viteServers = viteManager.getAllServers();
+      logger.info(`Vite servers count: ${viteServers.length}`);
+
       for (const { path, server: viteServer } of viteServers) {
+        logger.info(`Checking Vite route: ${path} against URL: ${urlPath}`);
         // Vite HMR WebSocket connections are typically at the base path or /@vite/client
         if (urlPath.startsWith(path)) {
-          logger.verbose(`Vite HMR WebSocket upgrade: ${urlPath} (route: ${path})`);
+          logger.info(`Vite HMR WebSocket upgrade: ${urlPath} (route: ${path})`);
           // Access the underlying ws WebSocketServer instance
           const wss = (viteServer.ws as any).wss;
           if (wss && wss.handleUpgrade) {
@@ -143,6 +148,8 @@ async function startServer(
               wss.emit('connection', ws, req);
             });
             return;
+          } else {
+            logger.error(`Vite WebSocket server not available for route: ${path}`);
           }
         }
       }

--- a/revx/src/index.ts
+++ b/revx/src/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 program
   .name('revx')
   .description('Multi-Vite project development server')
-  .version('1.0.1');
+  .version('1.0.2');
 
 program
   .command('start')


### PR DESCRIPTION
WebSocket接続のデバッグを容易にするためのログを追加

追加したログ:
- WebSocket upgradeリクエストのURL
- 登録されているViteサーバーの数
- 各ViteルートとリクエストURLのマッチング状況
- WebSocketサーバーの可用性チェック

これにより、HMR接続の問題を詳細に追跡できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)