### PR TITLE
revx: Fix Vite HMR WebSocket infinite reload issue (v1.0.4)

### DIFF
--- a/revx/package.json
+++ b/revx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/revx",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Multi-Vite project development server - Host multiple Vite apps on a single port with unified routing",
   "homepage": "https://github.com/tamuto/infodb-cli/",
   "bugs": "https://github.com/tamuto/infodb-cli/issues",

--- a/revx/src/commands/start.ts
+++ b/revx/src/commands/start.ts
@@ -132,8 +132,7 @@ async function startServerListen(
     const port = config.server.port;
     const host = config.server.host || '0.0.0.0';
 
-    // Handle WebSocket upgrade requests for proxied routes
-    // Note: Vite HMR WebSocket is now handled automatically by Vite using the parent HTTP server
+    // Handle WebSocket upgrade requests for proxied routes and Vite HMR
     server.on('upgrade', (req, socket, head) => {
       const urlPath = req.url || '/';
 
@@ -153,6 +152,13 @@ async function startServerListen(
             return;
           }
         }
+      }
+
+      // Check if this is a Vite HMR WebSocket request
+      if (viteManager.hasViteRoute(urlPath)) {
+        logger.verbose(`WebSocket upgrade for Vite HMR: ${urlPath}`);
+        // Let Vite's WebSocket handler (already registered on the HTTP server) handle it
+        return;
       }
 
       // If no route matched, close the socket

--- a/revx/src/index.ts
+++ b/revx/src/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 program
   .name('revx')
   .description('Multi-Vite project development server')
-  .version('1.0.3');
+  .version('1.0.4');
 
 program
   .command('start')

--- a/revx/src/utils/vite-middleware.ts
+++ b/revx/src/utils/vite-middleware.ts
@@ -103,4 +103,18 @@ export class ViteMiddlewareManager {
       server,
     }));
   }
+
+  hasViteRoute(urlPath: string): boolean {
+    // Check if any Vite route matches this URL path
+    for (const routePath of this.viteServers.keys()) {
+      // Remove trailing /* if present
+      const normalizedRoute = routePath.replace(/\/\*$/, '');
+
+      // Check if URL starts with this route path
+      if (urlPath === normalizedRoute || urlPath.startsWith(normalizedRoute + '/') || urlPath.startsWith(normalizedRoute + '?')) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
WebSocket upgrade handler now properly handles Vite HMR requests by checking if the request path matches a Vite route before destroying the socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)