### PR TITLE
lctl: Add TypeScript/Node.js Lambda support (v0.11.0)

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {
@@ -26,6 +26,7 @@
     "archiver": "^7.0.1",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",
+    "esbuild": "^0.25.0",
     "express": "^5.1.0",
     "glob": "^13.0.0",
     "yaml": "^2.8.1"

--- a/lctl/pnpm-lock.yaml
+++ b/lctl/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       commander:
         specifier: ^14.0.2
         version: 14.0.2
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       express:
         specifier: ^5.1.0
         version: 5.1.0

--- a/lctl/sample/configs/test_ts_lambda.yaml
+++ b/lctl/sample/configs/test_ts_lambda.yaml
@@ -1,0 +1,37 @@
+# Example TypeScript Lambda function configuration
+runtime: nodejs20.x
+handler: index.handler
+role: arn:aws:iam::123456789012:role/lambda-execution-role
+memory: 256
+timeout: 30
+description: "Test TypeScript Lambda function for lctl"
+
+# Node.js dependencies to install and bundle
+requirements:
+  - axios
+  - lodash
+
+# Additional files to include (non-JS/TS files only - source files are bundled automatically)
+files:
+  - config.json
+
+# Environment variables
+environment:
+  NODE_ENV: production
+  DEBUG: "false"
+
+# Permissions
+permissions:
+  - service: apigateway
+    source_arn: "arn:aws:execute-api:us-east-1:123456789012:*"
+    statement_id: "api-gateway-invoke"
+
+# Log settings
+log_retention_days: 14
+auto_create_log_group: true
+
+# Tags
+tags:
+  Environment: development
+  Project: lctl-test
+  Language: typescript

--- a/lctl/sample/functions/config.json
+++ b/lctl/sample/functions/config.json
@@ -1,0 +1,5 @@
+{
+  "apiEndpoint": "https://api.example.com",
+  "maxRetries": 3,
+  "timeout": 5000
+}

--- a/lctl/sample/functions/index.ts
+++ b/lctl/sample/functions/index.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import _ from 'lodash';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+
+// Load config (will be included in ZIP as additional file)
+import config from './config.json';
+
+interface ResponseBody {
+  message: string;
+  timestamp: string;
+  requestId: string;
+  config: typeof config;
+}
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+  context: Context
+): Promise<APIGatewayProxyResult> => {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  try {
+    // Example: using axios
+    const response = await axios.get('https://httpbin.org/get', {
+      timeout: config.timeout,
+    });
+
+    // Example: using lodash
+    const data = _.pick(response.data, ['origin', 'url']);
+
+    const body: ResponseBody = {
+      message: 'Hello from TypeScript Lambda!',
+      timestamp: new Date().toISOString(),
+      requestId: context.awsRequestId,
+      config,
+    };
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ...body, httpbinData: data }),
+    };
+  } catch (error) {
+    console.error('Error:', error);
+
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: 'Internal Server Error',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -15,7 +15,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.10.1');
+  .version('0.11.0');
 
 // Deploy command
 program


### PR DESCRIPTION
Add automatic TypeScript bundling with esbuild for Node.js Lambda functions. Runtime is auto-detected from the 'runtime' field (nodejs* triggers esbuild). Dependencies specified in 'requirements' are installed via npm and bundled. @aws-sdk/* packages are automatically excluded (available in Lambda runtime).