### PR TITLE
lctl: Fix environment variables parsing for special characters (v0.12.1)

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -15,7 +15,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.12.0');
+  .version('0.12.1');
 
 // Deploy command
 program

--- a/lctl/src/utils/script-generator.ts
+++ b/lctl/src/utils/script-generator.ts
@@ -76,20 +76,8 @@ echo "✅ Lambda function ${functionName} deployed successfully!"
       return '';
     }
 
-    let section = '# Environment Variables\n';
-    section += 'ENVIRON="Variables={"\n';
-
-    const envVars = Object.entries(config.environment);
-    envVars.forEach(([key, value], index) => {
-      section += `ENVIRON+="${key}=${value}`;
-      if (index < envVars.length - 1) {
-        section += ',';
-      }
-      section += '"\n';
-    });
-
-    section += 'ENVIRON+="}"\n\n';
-    return section;
+    const envJson = JSON.stringify({ Variables: config.environment });
+    return `# Environment Variables\nENVIRON='${envJson}'\n\n`;
   }
 
   private generateLayersSection(config: LambdaConfig): string {


### PR DESCRIPTION
Use JSON format for --environment flag to handle special characters like [], ;, $ in environment variable values.