### PR TITLE
lctl: Remove existing permission before adding to avoid conflicts (v0…

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -15,7 +15,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.12.1');
+  .version('0.12.2');
 
 // Deploy command
 program

--- a/lctl/src/utils/script-generator.ts
+++ b/lctl/src/utils/script-generator.ts
@@ -182,6 +182,11 @@ aws lambda wait function-active --function-name ${functionName}\n`;
         throw new Error(`Permission at index ${index} must specify either 'principal' or 'service'`);
       }
 
+      // Remove existing permission first (ignore error if not exists)
+      section += `aws lambda remove-permission \\
+        --function-name ${functionName} \\
+        --statement-id ${statementId} 2>/dev/null || true\n`;
+
       section += `aws lambda add-permission \\
         --function-name ${functionName} \\
         --statement-id ${statementId} \\


### PR DESCRIPTION
….12.2)

Add remove-permission before add-permission in deploy scripts to handle cases where the statement ID already exists, preventing ResourceConflictException.