### PR TITLE
lctl: Fix VPC detachment by explicitly clearing VPC config on update …

### DIFF
--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -15,7 +15,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.12.3');
+  .version('0.12.4');
 
 // Deploy command
 program

--- a/lctl/src/utils/aws-cli.ts
+++ b/lctl/src/utils/aws-cli.ts
@@ -160,13 +160,14 @@ export class AwsCliManager {
     }
 
     // Set VPC configuration
-    if (config.vpc) {
-      await this.runAwsCommand([
-        'lambda', 'update-function-configuration',
-        '--function-name', functionName,
-        '--vpc-config', `SubnetIds=${config.vpc.subnets.join(',')},SecurityGroupIds=${config.vpc.security_groups.join(',')}`,
-      ]);
-    }
+    const vpcConfig = config.vpc
+      ? `SubnetIds=${config.vpc.subnets.join(',')},SecurityGroupIds=${config.vpc.security_groups.join(',')}`
+      : 'SubnetIds=[],SecurityGroupIds=[]';
+    await this.runAwsCommand([
+      'lambda', 'update-function-configuration',
+      '--function-name', functionName,
+      '--vpc-config', vpcConfig,
+    ]);
 
     // Set dead letter queue
     if (config.dead_letter_queue) {

--- a/lctl/src/utils/script-generator.ts
+++ b/lctl/src/utils/script-generator.ts
@@ -28,7 +28,7 @@ if aws lambda get-function --function-name ${functionName} &> /dev/null; then
         --handler ${config.handler} \\
         --role ${config.role} \\
         --timeout ${config.timeout || 3} \\
-        --memory-size ${config.memory || 128}${this.generateEnvironmentVariablesFlag(config)}${this.generateLayersFlag(config)}${this.generateDescriptionFlag(config)}${this.generateVpcFlag(config)} | jq .
+        --memory-size ${config.memory || 128}${this.generateEnvironmentVariablesFlag(config)}${this.generateLayersFlag(config)}${this.generateDescriptionFlag(config)}${this.generateVpcFlag(config, true)} | jq .
 
     # 関数の更新が完了するまで待機
     aws lambda wait function-updated --function-name ${functionName}
@@ -41,7 +41,7 @@ else
         --architectures ${config.architecture || 'x86_64'} \\
         --timeout ${config.timeout || 3} \\
         --memory-size ${config.memory || 128} \\
-        --role ${config.role}${this.generateEnvironmentVariablesFlag(config)}${this.generateLayersFlag(config)}${this.generateDescriptionFlag(config)}${this.generateVpcFlag(config)} | jq .
+        --role ${config.role}${this.generateEnvironmentVariablesFlag(config)}${this.generateLayersFlag(config)}${this.generateDescriptionFlag(config)}${this.generateVpcFlag(config, false)} | jq .
 fi
 
 # 共通の追加設定
@@ -112,13 +112,16 @@ echo "✅ Lambda function ${functionName} deployed successfully!"
   }
 
 
-  private generateVpcFlag(config: LambdaConfig): string {
-    if (!config.vpc) {
-      return '';
+  private generateVpcFlag(config: LambdaConfig, isUpdate: boolean = false): string {
+    if (config.vpc) {
+      const subnetIds = config.vpc.subnets.join(',');
+      const securityGroupIds = config.vpc.security_groups.join(',');
+      return ` \\\n        --vpc-config "SubnetIds=${subnetIds},SecurityGroupIds=${securityGroupIds}"`;
     }
-    const subnetIds = config.vpc.subnets.join(',');
-    const securityGroupIds = config.vpc.security_groups.join(',');
-    return ` \\\n        --vpc-config "SubnetIds=${subnetIds},SecurityGroupIds=${securityGroupIds}"`;
+    if (isUpdate) {
+      return ' \\\n        --vpc-config "SubnetIds=[],SecurityGroupIds=[]"';
+    }
+    return '';
   }
 
   private generateAdditionalConfigurationCommands(functionName: string, config: LambdaConfig): string {


### PR DESCRIPTION
…(v0.12.4)

When VPC config was removed from YAML, the --vpc-config flag was simply omitted from update-function-configuration, which left the existing VPC config unchanged. Now explicitly passes empty SubnetIds/SecurityGroupIds to properly detach Lambda from VPC.