### PR TITLE
lctl: Add --output-dir option to makezip and export (v0.15.0)

### DIFF
--- a/lctl/README.md
+++ b/lctl/README.md
@@ -73,6 +73,7 @@ pnpx @infodb/lctl makezip <config-name> [オプション]
 - `config-name`: 設定ファイル名（.yaml拡張子は不要）
 
 **オプション:**
+- `--output-dir <dir>`: ZIPパッケージの出力先ディレクトリ（デフォルト: カレントディレクトリ）
 - `--verbose`: 詳細なログを出力
 
 **機能:**
@@ -83,6 +84,7 @@ pnpx @infodb/lctl makezip <config-name> [オプション]
 **例:**
 ```bash
 pnpx @infodb/lctl makezip my-function --verbose
+pnpx @infodb/lctl makezip my-function --output-dir ./dist
 ```
 
 ### 2. deploy - Lambda関数の完全デプロイ（推奨）
@@ -120,6 +122,7 @@ pnpx @infodb/lctl export <config-name> [オプション]
 
 **オプション:**
 - `--output <file>`: 出力ファイルパス（デフォルト: deploy-{config-name}.sh）
+- `--output-dir <dir>`: スクリプトの出力先ディレクトリ（デフォルト: カレントディレクトリ、`--output`指定時は無視）
 - `--verbose`: 詳細なログを出力
 
 **機能:**
@@ -133,6 +136,10 @@ pnpx @infodb/lctl export my-function
 
 # カスタム出力ファイル
 pnpx @infodb/lctl export my-function --output custom-deploy.sh
+
+# 出力先ディレクトリを指定（makezipと同じディレクトリを指定するとそのままデプロイに使える）
+pnpx @infodb/lctl makezip my-function --output-dir ./dist
+pnpx @infodb/lctl export my-function --output-dir ./dist
 ```
 
 ### 4. delete - Lambda関数の削除
@@ -249,6 +256,7 @@ pnpx @infodb/lctl export <config-name> [オプション]
 
 **オプション:**
 - `--output <file>`: 出力ファイルパス（デフォルト: deploy-{config-name}.sh）
+- `--output-dir <dir>`: スクリプトの出力先ディレクトリ（デフォルト: カレントディレクトリ、`--output`指定時は無視）
 - `--verbose`: 詳細なログを出力
 
 **例:**

--- a/lctl/package.json
+++ b/lctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infodb/lctl",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "AWS Lambda Control Tool - Simple CLI for managing Lambda functions",
   "main": "dist/index.js",
   "bin": {

--- a/lctl/src/commands/export.ts
+++ b/lctl/src/commands/export.ts
@@ -1,10 +1,12 @@
 import chalk from 'chalk';
+import * as path from 'path';
 import { ConfigManager } from '../utils/config';
 import { ScriptGenerator } from '../utils/script-generator';
 import { Logger } from '../utils/logger';
 
 export interface ExportOptions {
   output?: string;
+  outputDir?: string;
   verbose?: boolean;
 }
 
@@ -26,7 +28,7 @@ export async function exportCommand(functionName: string, options: ExportOptions
     const script = scriptGenerator.generateDeployScript(actualFunctionName, config, functionName);
 
     // Save script
-    const outputPath = options.output || `deploy-${functionName}.sh`;
+    const outputPath = options.output || path.join(options.outputDir || '.', `deploy-${functionName}.sh`);
     const scriptPath = await scriptGenerator.saveScript(outputPath, script);
 
     logger.success(`✅ Deploy script exported successfully: ${chalk.cyan(scriptPath)}`);

--- a/lctl/src/commands/makezip.ts
+++ b/lctl/src/commands/makezip.ts
@@ -22,6 +22,7 @@ function getEntryFileFromHandler(handler: string): string {
 }
 
 export interface MakeZipOptions {
+  outputDir?: string;
   verbose?: boolean;
 }
 
@@ -42,6 +43,11 @@ export async function makeZipCommand(functionName: string, options: MakeZipOptio
     const functionsDir = config.functionsDirectory || 'functions';
     const vendorDir = path.join(functionsDir, 'vendor');
     const zipFileName = `${functionName}.zip`;
+    const outputDir = path.resolve(options.outputDir || '.');
+    const zipPath = path.join(outputDir, zipFileName);
+
+    // Ensure output directory exists
+    await fs.mkdir(outputDir, { recursive: true });
 
     // Remove existing vendor directory if it exists
     try {
@@ -54,9 +60,9 @@ export async function makeZipCommand(functionName: string, options: MakeZipOptio
 
     // Remove existing ZIP file if it exists
     try {
-      await fs.access(zipFileName);
-      logger.verbose(`Removing existing ZIP file: ${zipFileName}`);
-      await fs.unlink(zipFileName);
+      await fs.access(zipPath);
+      logger.verbose(`Removing existing ZIP file: ${zipPath}`);
+      await fs.unlink(zipPath);
     } catch (error) {
       // File doesn't exist, continue
     }
@@ -73,7 +79,7 @@ export async function makeZipCommand(functionName: string, options: MakeZipOptio
         logger
       );
 
-      await createNodeDeploymentZip(bundledFile, functionsDir, config, zipFileName, logger);
+      await createNodeDeploymentZip(bundledFile, functionsDir, config, zipFileName, outputDir, logger);
     } else {
       // Python Lambda (existing behavior)
       logger.info(`Runtime: ${chalk.cyan(config.runtime)} (Python)`);
@@ -85,10 +91,10 @@ export async function makeZipCommand(functionName: string, options: MakeZipOptio
       }
 
       // Create deployment ZIP
-      await createDeploymentZip(functionsDir, config, zipFileName, logger);
+      await createDeploymentZip(functionsDir, config, zipFileName, outputDir, logger);
     }
 
-    logger.success(`✅ Deployment package created successfully: ${chalk.cyan(zipFileName)}`);
+    logger.success(`✅ Deployment package created successfully: ${chalk.cyan(zipPath)}`);
 
   } catch (error) {
     logger.error(`❌ Failed to create deployment package: ${error instanceof Error ? error.message : error}`);
@@ -212,6 +218,7 @@ async function createNodeDeploymentZip(
   functionsDir: string,
   config: any,
   zipFileName: string,
+  outputDir: string,
   logger: Logger
 ): Promise<void> {
   logger.info('Creating ZIP package for Node.js Lambda...');
@@ -257,8 +264,8 @@ async function createNodeDeploymentZip(
     process.chdir(tempDir);
     await runCommand('zip', ['-r', zipFileName, '.'], logger);
 
-    // Move ZIP to project root
-    await fs.rename(zipFileName, path.join(originalCwd, zipFileName));
+    // Move ZIP to output directory
+    await moveFile(zipFileName, path.join(outputDir, zipFileName));
 
   } finally {
     process.chdir(originalCwd);
@@ -268,7 +275,7 @@ async function createNodeDeploymentZip(
   }
 }
 
-async function createDeploymentZip(functionsDir: string, config: any, zipFileName: string, logger: Logger): Promise<void> {
+async function createDeploymentZip(functionsDir: string, config: any, zipFileName: string, outputDir: string, logger: Logger): Promise<void> {
   logger.info('Creating ZIP package...');
 
   // Change to functions directory
@@ -314,8 +321,8 @@ async function createDeploymentZip(functionsDir: string, config: any, zipFileNam
       await runCommand('zip', ['-r', `../${zipFileName}`, '.'], logger);
       process.chdir('..');
 
-      // Move ZIP to project root
-      await fs.rename(zipFileName, path.join('..', zipFileName));
+      // Move ZIP to output directory
+      await moveFile(zipFileName, path.join(outputDir, zipFileName));
 
       // Clean up temp directory
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -333,6 +340,20 @@ async function createDeploymentZip(functionsDir: string, config: any, zipFileNam
   } finally {
     // Always return to original directory
     process.chdir(originalCwd);
+  }
+}
+
+async function moveFile(src: string, dest: string): Promise<void> {
+  try {
+    await fs.rename(src, dest);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EXDEV') {
+      // Source and destination are on different filesystems; fall back to copy + delete
+      await fs.copyFile(src, dest);
+      await fs.unlink(src);
+    } else {
+      throw error;
+    }
   }
 }
 

--- a/lctl/src/index.ts
+++ b/lctl/src/index.ts
@@ -15,7 +15,7 @@ const program = new Command();
 program
   .name('lctl')
   .description('AWS Lambda Control Tool - Simple CLI for managing Lambda functions')
-  .version('0.14.1');
+  .version('0.15.0');
 
 // Deploy command
 program
@@ -46,6 +46,7 @@ program
   .command('makezip')
   .description('Create deployment ZIP package')
   .argument('<function-name>', 'Configuration file name (without .yaml extension)')
+  .option('--output-dir <dir>', 'Output directory for the ZIP package (default: current directory)')
   .option('--verbose', 'Verbose output')
   .action(makeZipCommand);
 
@@ -55,6 +56,7 @@ program
   .description('Export deployment script')
   .argument('<function-name>', 'Configuration file name (without .yaml extension)')
   .option('--output <file>', 'Output script file path')
+  .option('--output-dir <dir>', 'Output directory for the deploy script (default: current directory)')
   .option('--verbose', 'Verbose output')
   .action(exportCommand);
 

--- a/lctl/src/utils/script-generator.ts
+++ b/lctl/src/utils/script-generator.ts
@@ -453,6 +453,7 @@ aws logs put-retention-policy --log-group-name /aws/lambda/${functionName} --ret
 
   async saveScript(outputPath: string, script: string): Promise<string> {
     const scriptPath = path.resolve(outputPath);
+    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
     await fs.writeFile(scriptPath, script, { mode: 0o755 });
     this.logger.verbose(`Deploy script saved: ${scriptPath}`);
     return scriptPath;


### PR DESCRIPTION
- makezip: write the ZIP to a specified output directory instead of always using the current directory; auto-creates the directory and falls back to copy+unlink when rename fails across filesystems (EXDEV)
- export: write the deploy script to a specified output directory (ignored when --output gives an explicit file path); saveScript now creates the destination directory if missing
- Generated scripts still reference the ZIP by relative filename, so makezip and export should be pointed at the same --output-dir


Claude-Session: https://claude.ai/code/session_014MsPFJgkyhA9DhkD83cZY2