### PR TITLE
lctl: Surface permission errors and document required IAM policy

### DIFF
--- a/lctl/README.md
+++ b/lctl/README.md
@@ -471,6 +471,92 @@ export AWS_DEFAULT_REGION=us-east-1
 
 3. IAMロールの使用（EC2、Lambda等）
 
+## 必要なIAM権限
+
+`lctl`自体はAWS CLIを呼び出すラッパーなので、実行するユーザー/ロールには以下のIAM権限が必要です。`--action`に何を指定していても、`add-permission`/`remove-permission`の呼び出しに必要なIAMアクションは常に`lambda:AddPermission`/`lambda:RemovePermission`です（`--action`はリソースベースポリシー側で許可する対象を指定するものであり、呼び出し元のIAM権限とは別物です）。
+
+### `deploy` / `export`で生成されるスクリプトの実行に必要な権限
+
+| 権限 | 用途 |
+|---|---|
+| `lambda:GetFunction` | 関数の存在確認、`wait function-updated`、タグ付け時のARN取得 |
+| `lambda:CreateFunction` | 新規関数の作成 |
+| `lambda:UpdateFunctionCode` | 既存関数のコード更新 |
+| `lambda:UpdateFunctionConfiguration` | 設定更新（VPC、デッドレターキュー、エフェメラルストレージを含む） |
+| `lambda:PutFunctionConcurrency` | `reserved_concurrency`設定時 |
+| `lambda:DeleteFunctionConcurrency` | `reserved_concurrency`未設定時、既存の予約済み同時実行数の解除 |
+| `lambda:TagResource` | `tags`設定時 |
+| `lambda:AddPermission` | `permissions`設定、Function URLの公開許可 |
+| `lambda:RemovePermission` | 上記の再デプロイ時のクリーンアップ |
+| `lambda:GetFunctionUrlConfig` | Function URL設定の存在確認・表示 |
+| `lambda:CreateFunctionUrlConfig` | Function URLの新規作成 |
+| `lambda:UpdateFunctionUrlConfig` | Function URLの設定更新 |
+| `lambda:DeleteFunctionUrlConfig` | `function_url`未設定時の既存設定削除 |
+| `logs:DescribeLogGroups` | ロググループの存在確認 |
+| `logs:CreateLogGroup` | ロググループの作成（`auto_create_log_group: true`時） |
+| `logs:PutRetentionPolicy` | ログ保持期間の設定 |
+| `iam:PassRole`（対象: `role`に指定したLambda実行ロールのARN） | 関数の作成・更新時にLambda実行ロールを渡すために必須 |
+
+### `delete`コマンドに必要な権限
+
+| 権限 | 用途 |
+|---|---|
+| `lambda:DeleteFunctionUrlConfig` | Function URL設定の削除 |
+| `lambda:DeleteFunction` | 関数の削除 |
+
+### `info`コマンドに必要な権限
+
+| 権限 | 用途 |
+|---|---|
+| `lambda:GetFunction` | 関数情報の取得 |
+| `lambda:GetFunctionUrlConfig` | Function URL情報の取得 |
+
+### IAMポリシー例
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:GetFunction",
+        "lambda:CreateFunction",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:PutFunctionConcurrency",
+        "lambda:DeleteFunctionConcurrency",
+        "lambda:TagResource",
+        "lambda:AddPermission",
+        "lambda:RemovePermission",
+        "lambda:GetFunctionUrlConfig",
+        "lambda:CreateFunctionUrlConfig",
+        "lambda:UpdateFunctionUrlConfig",
+        "lambda:DeleteFunctionUrlConfig",
+        "lambda:DeleteFunction"
+      ],
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT_ID:function:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:CreateLogGroup",
+        "logs:PutRetentionPolicy"
+      ],
+      "Resource": "arn:aws:logs:REGION:ACCOUNT_ID:log-group:/aws/lambda/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/lambda-execution-role"
+    }
+  ]
+}
+```
+
+`Resource`はできるだけ絞り込み、対象のLambda関数・ロググループ・実行ロールのARNに限定することを推奨します。
+
 ## トラブルシューティング
 
 ### よくある問題

--- a/lctl/src/utils/script-generator.ts
+++ b/lctl/src/utils/script-generator.ts
@@ -199,6 +199,11 @@ __lctl_escape() {
     if (config.reserved_concurrency !== undefined) {
       commands += `\n# Set reserved concurrency\n`;
       commands += `aws lambda put-function-concurrency --function-name ${functionName} --reserved-concurrent-executions ${config.reserved_concurrency} | pp\n`;
+    } else {
+      // 未設定なら既存の予約済み同時実行数を解除する（失敗は許容するが、権限不足等の
+      // 実エラーが分かるよう stderr は隠さない）
+      commands += `\n# 予約済み同時実行数: 未設定なので、既存の設定があれば解除\n`;
+      commands += `aws lambda delete-function-concurrency --function-name ${functionName} || true\n`;
     }
 
     // Dead letter queue
@@ -253,10 +258,11 @@ aws lambda wait function-updated --function-name ${functionName}\n`;
         throw new Error(`Permission at index ${index} must specify either 'principal' or 'service'`);
       }
 
-      // Remove existing permission first (ignore error if not exists)
+      // Remove existing permission first. Failure is tolerated (e.g. it doesn't exist yet),
+      // but stderr is shown so real problems (e.g. missing lambda:RemovePermission) are visible.
       section += `aws lambda remove-permission \\
         --function-name ${functionName} \\
-        --statement-id ${statementId} 2>/dev/null || true\n`;
+        --statement-id ${statementId} || true\n`;
 
       section += `aws lambda add-permission \\
         --function-name ${functionName} \\
@@ -304,9 +310,11 @@ aws lambda wait function-updated --function-name ${functionName}\n`;
   private generateFunctionUrlSection(functionName: string, config: LambdaConfig): string {
     const invokeUrlStatementId = 'function-url-public-invoke-url';
     const invokeFunctionStatementId = 'function-url-public-invoke-function';
+    // Failure is tolerated (e.g. it doesn't exist yet), but stderr is shown so real
+    // problems (e.g. missing lambda:RemovePermission) are visible.
     const removeStatement = (id: string) => `aws lambda remove-permission \\
     --function-name ${functionName} \\
-    --statement-id ${id} 2>/dev/null || true`;
+    --statement-id ${id} || true`;
 
     if (!config.function_url) {
       return `


### PR DESCRIPTION
- Stop swallowing stderr on remove-permission calls (permissions and Function URL sections) so real failures (e.g. missing lambda:RemovePermission) are visible instead of silently ignored
- Reset reserved concurrency via delete-function-concurrency when reserved_concurrency is removed from config, matching the existing reset-on-unset pattern already used for VPC config
- Document the full IAM permission list (and a ready-to-use policy example) required for deploy/export/delete/info in README.md


Claude-Session: https://claude.ai/code/session_014MsPFJgkyhA9DhkD83cZY2